### PR TITLE
Migrate SDA-User-docs to the web portal

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,6 +22,28 @@
         {%- include author-links.html author=_site_author -%}
       </div>
     </div>
+    
+    <style type="text/css">
+      td
+      {
+          padding:0 75px 0 15px;
+      }
+      .custom_font{
+        font: 400 1rem/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+        font-size: 1rem;
+        font-weight: 400;
+      }
+      
+      </style>
+      <table>
+          <tr>
+              <td ><a class = "custom_font" href="/submitter_docs.html">Submitter Information</a></td>
+              <td><a class = "custom_font"  href="/requester_docs.html">Requester Information</a></td>
+              <td><a class = "custom_font"  href="/download_data.html">Download_data script</a></td>
+          </tr>
+      </table>
+
+      
     {%- include snippets/get-locale-string.html key='COPYRIGHT_DATES' -%}
     {%- assign _locale_copyright_dates = __return -%}
     <div class="site-info mt-2">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,11 +24,9 @@
     </div>
     
     <style type="text/css">
-      td
-      {
-          padding:0 75px 0 15px;
-      }
+
       .custom_font{
+        padding: 0 75px 0 15px;
         font: 400 1rem/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
         font-size: 1rem;
         font-weight: 400;
@@ -36,11 +34,9 @@
       
       </style>
       <table>
-          <tr>
               <td ><a class = "custom_font" href="/submitter_docs.html">Submitter Information</a></td>
               <td><a class = "custom_font"  href="/requester_docs.html">Requester Information</a></td>
               <td><a class = "custom_font"  href="/download_data.html">Download_data script</a></td>
-          </tr>
       </table>
 
       

--- a/bianca.md
+++ b/bianca.md
@@ -1,0 +1,153 @@
+---
+layout: article
+key: page-single
+---
+
+# Encryption of files for EGA-SE in Bianca
+
+This document is a how-to-guide on encrypting files in the Bianca sensitive data
+analysis system according to the
+[crypt4gh](https://www.ga4gh.org/news/crypt4gh-a-secure-method-for-sharing-human-genetic-data/)
+standard for submission to the SDA-SE service. The SDA provides permanent secure
+archiving and sharing of all types of potentially identifiable human genetic and
+phenotypic data.
+
+## Login to UPPMAX
+
+Bianca is part of UPPMAX, so start by logging in to UPPMAX. If you need a
+refresher, here are some helpful links:
+
+- [Uppmax Getting Started](https://www.uppmax.uu.se/support/getting-started/)
+
+- [Uppmax User Guides](https://www.uppmax.uu.se/support/user-guides/)
+
+- [Bianca User Guide](https://www.uppmax.uu.se/support/user-guides/bianca-user-guide/)
+
+## Install crypt4gh on bianca
+
+The guide assumes that the [instructions](binaries.html) for downloading and extracting
+`crypt4gh` have been followed.
+
+### Download the crypt4gh public key
+
+For the SDA to be able to understand the encrypted files when they are uploaded,
+they need to be encrypted with the correct public key. This key can be
+downloaded from this repository with this command:
+```bash
+wget https://raw.githubusercontent.com/NBISweden/EGA-SE-user-docs/main/crypt4gh_key.pub
+```
+
+### Upload keys and encryption tool to the wharf
+
+Bianca uses a system called the wharf to transfer files without having a direct
+connection to the internet. You can upload files to this system from the outside
+using sftp, or from uppmax by simply mounting the wharf drives. The guide for
+transferring files from and to Bianca can be found
+[here](https://www.uppmax.uu.se/support/user-guides/transit-user-guide/).
+
+From a terminal window, run the following commands to upload your `crypt4gh`
+binary and public key.
+
+* Login to transit running:
+  ```bash
+  ssh [username]@transit.uppmax.uu.se
+  ```
+
+* Mount to the bianca project folder using the following command
+  ```bash
+  mount_wharf [project_name]
+  ```
+  where `[project_name]` is your bianca project, formatted like 'sens20XXX'.
+
+  **Note** mounting the wharf follows the same procedure as logging in to
+  Bianca, so you will need to provide your password along with your two-factor
+  authentication code.
+
+* Copy the binary and public key files to the project drive in the wharf using the `cp` command:
+
+  ```bash
+  cp crypt4gh* ~/<project_name>/
+  ```
+
+### Move keys and image into Bianca
+
+You can now log out from the wharf and log in to bianca to transfer the files
+out of the wharf and in to your project.
+
+* Login to bianca running:
+
+  ```bash
+  ssh -A [username]-[project_name]@bianca.uppmax.uu.se
+  ```
+  (Remember to use your two-factor authenticator along with your password)
+
+* Copy the files from
+  `/proj/[project_name]/nobackup/wharf/[username]/[username]-[project_name]`
+  to the folder you want to store the image using the `cp` command:
+
+  ```bash
+  cp /proj/[project_name]/nobackup/wharf/[username]/[username]-[project_name]/crypt4gh* .
+  ```
+
+Running the `ls` command in this folder, you should be able to see the
+`crypt4gh`, and `crypt4gh_key.pub` files.
+
+## Encrypt your sensitive data
+
+Now you have the public key, and the tools you need, so it's time to encrypt the
+submission files. An encryption key will be created automatically by the tool,
+but if you prefer to use a specific key, you can provide one using the `-s`
+argument.
+
+* (optional) Create a key pair
+
+  The creation of a key pair is very simple using `crypt4gh`. Run the following
+  command, using any name instead of [my-key]:
+​
+   ```bash
+   crypt4gh generate --name=[my-key]
+   ```
+
+   To verify that the key pair was created, run the `ls` command and make sure
+   the keys you specified exist in the folder.
+
+* Encrypt the files
+
+   Now that you have the public key, and the tools you need, you can encrypt the
+   submission files. An encryption key will be created automatically by the
+   tool, but if you prefer to use a specific key, you can provide one using the
+   `-s` argument.
+
+   ```bash
+   ./crypt4gh encrypt -p crypt4gh_key.pub -f [my-file]
+   ```
+
+   To encrypt with a given secret key use:
+
+   ```bash
+   ./crypt4gh encrypt -p crypt4gh_key.pub -f [my-file] -s [my-key].sec.pem
+   ```
+
+## Move encrypted files to the wharf for upload
+
+Moving the files back uses the same steps as uploading, but "backwards"
+
+1) On Bianca, move the encrypted files to your wharf directory:
+   ```bash
+   mv *.c4gh /proj/[project_name]/nobackup/wharf/[username]/[username]-[project_name]
+   ```
+
+2) Log back in to UPPMAX transit and mount the wharf drive again:
+   ```bash
+   ssh [username]@transit.uppmax.uu.se
+   mount_wharf [project_name]
+   ```
+
+   The encrypted files should be secure enough to keep on UPPMAX while they are
+   uploaded to the submission system. If you prefer to make the submission from
+   a different system than UPPMAX, see the
+   [Bianca user guide](https://www.uppmax.uu.se/support/user-guides/bianca-user-guide/)
+   on how to download the encrypted files from the wharf using sftp.
+
+Once the submission ready files are downloaded, head over to the
+[submitting](/submitter_docs) guide to continue.

--- a/binaries.md
+++ b/binaries.md
@@ -1,0 +1,102 @@
+---
+layout: article
+key: page-single
+---
+
+# Setting up with binaries
+
+The crypt4gh and s3cmd tools are available as binaries, so you can download the tar
+files, extract them and use the tools. Depending on your operating system, select
+the appropriate version and download it from the command line with `wget`.
+
+## Download the tools
+The list of releases for `s3cmd` for Linux based systems can be found [here](https://github.com/s3tools/s3cmd/releases/tag/v2.2.0), for Windows systems [here](https://www.s3express.com/download.htm),
+while for the `crypt4gh` [here](https://github.com/elixir-oslo/crypt4gh/releases/tag/v1.3.0).
+
+For example, if your operating system is Linux based, download the files using:
+```bash
+wget https://github.com/s3tools/s3cmd/releases/download/v2.2.0/s3cmd-2.2.0.tar.gz
+wget https://github.com/elixir-oslo/crypt4gh/releases/download/v1.3.0/crypt4gh_linux_x86_64.tar.gz
+```
+
+## Check the python version
+The `s3cmd` tool requires python version higher than 3. Check that this is the case in your system using
+```bash
+python --version
+```
+If the version is `2.X.X`, follow the instructions in the next section to [create a virtual environment](binaries.html#create-a-virtual-environment)
+with python 3. Otherwise, move to section [Extract the executables](binaries.html#extract-the-executables).
+
+### Create a virtual environment
+​
+The python virtual environment tools come bundled with python since version
+3.4, and ​the syntax is the same on all platforms.
+
+```bash
+python3 -m venv venv
+```
+
+This will create a folder called `venv` under the current directory. To activate
+the environment run the following command from the terminal (this command has
+to be run every time a new terminal window is opened):​
+
+* Linux and macOS
+​
+  ```bash
+  source venv/bin/activate
+  ```
+
+* Windows
+
+  ```PowerShell
+  .\venv\Scripts\activate
+  ```
+
+  **Note** PowerShell doesn't normally allow script execution, and you may need
+  to run
+  ```PowerShell
+  Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+  ```
+  before you can activate the virtual environment.
+If the version is `2.X.X`, 
+
+## Extract the executables
+To extract the binary for the `crypt4gh` use the tar command 
+```bash
+tar -xvzf crypt4gh_linux_x86_64.tar.gz
+```
+The `crypt4gh` executable should be in the same directory. Make sure you have the correct version running
+```bash
+./crypt4gh --version
+```
+
+To extract the binary for the `s3cmd` use the tar command 
+```bash
+tar -xvzf s3cmd-2.2.0.tar.gz
+```
+The executable should be under the `s3cmd-2.2.0` directory. Make sure you have the correct version running
+```bash
+./s3cmd-2.2.0/s3cmd --version
+```
+If this command returns an error, check the [troubleshooting](binaries.html#troubleshooting) section for possible solutions
+
+Now you should be able to go on to
+[encrypting your files](submitter_docs.html#encrypting).
+
+## Troubleshooting
+
+- If the `s3cmd` commands return the following error
+    ```bash
+    ImportError trying to import dateutil.parser.
+    Please install the python dateutil module:
+    $ sudo apt-get install python-dateutil
+    or
+    $ sudo yum install python-dateutil
+    or
+    $ pip install python-dateutil
+    ```
+
+    run the following command inside the environment and try again
+    ```bash
+    pip install python-dateutil
+    ```

--- a/checksums.md
+++ b/checksums.md
@@ -1,0 +1,71 @@
+---
+layout: article
+key: page-single
+---
+
+
+# Calculating checksums of files
+
+Checksums are short, fixed length strings that can be calculated from
+arbitrarily large inputs. They are commonly used to validate the contents of
+files, as the checksum will change considerably even with minimal changes to the
+input. More information can be found on
+[Wikipedia](https://en.wikipedia.org/wiki/Checksum).
+
+## Linux and OS X
+
+The commands for calculating checksums are very similar on Linux and OS X. They
+use the same tool for calculating sha256 checksums, but linux use the `md5sum`
+command for md5 checksums, while the OS X command is `md5`.
+
+```bash
+# Calculate md5 checksum on linux
+md5sum <my-file> <my-encrypted-file>.c4gh
+# ... and OS X
+md5 <my-file> <my-encrypted-file>.c4gh
+# The sha256 checksum command is the same on both platforms
+shasum -a 256 <my-file> <my-encrypted-file>.c4gh
+```
+​
+The results can be written to a file using the `>` operator:
+
+ex.
+```bash
+md5sum <my-file> <my-encrypted-file>.c4gh > <my-files>.md5
+```
+
+## Windows
+
+**Note** We couldn't find a windows computer to test on, so please tell us if
+these instructions don't work anymore.
+
+Installing on windows is done using Windows PowerShell. You can find PowerShell
+by right-clicking on the windows menu button. The tool we recommend for windows
+is [md5checker](https://pypi.org/project/md5checker/).
+
+To run `pip` to install `md5checker` you need to run PowerShell as
+Administrator (unless you run in the virtual environment), but once the tool is
+installed, you should run `md5checker` in a normal non-Administrator shell for
+security reasons.
+
+```PowerShell
+pip install md5checker
+```
+Then get the md5 checksum for each file with:
+
+```PowerShell
+md5checker <my-file>
+```
+
+and the sha-256 checksum with:
+
+```PowerShell
+md5checker <my-file> -a sha256
+```
+​
+The `>` operator works the same in PowerShell as it does in linux and OS X, so
+you can use the same syntax to write the output to a file.
+
+```PowerShell
+md5checker <my-file> > <my-file>.md5
+```

--- a/download_data.md
+++ b/download_data.md
@@ -1,0 +1,38 @@
+---
+layout: article
+title: Download data script
+key: page-single
+---
+
+
+
+Following script is used to download the encrypted data files from the text file. It allows you to maintain the structure of the dataset.
+
+<a href="/download_data.sh" download="download_data.sh"><button class="btn"><i class="fa fa-download"></i> Download</button></a>
+
+```bash
+#!/bin/bash
+
+# Parse input argument if exist else use default
+input=${1:-urls_list.txt}
+
+# Name of the folder that the url will be cut in
+# order to create the directory structure locally
+folder="/public/"
+folder_length=${#folder}
+
+# Read the url list line by line
+while IFS= read -r line; do
+  i=0
+  url_length=${#line}
+  # Local path where the file will be downloaded
+  full_path=${line##*$folder}
+  # Download files and keep the folders structure
+  echo -e "Downloading data from $line \n"
+  mkdir -p $(dirname $full_path)
+  curl $line --output $full_path
+  echo "File saved in $full_path"
+  echo -e "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - \n"
+done < "$input"
+```
+

--- a/download_data.sh
+++ b/download_data.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Parse input argument if exist else use default
+input=${1:-urls_list.txt}
+
+# Name of the folder that the url will be cut in
+# order to create the directory structure locally
+folder="/public/"
+folder_length=${#folder}
+
+# Read the url list line by line
+while IFS= read -r line; do
+  i=0
+  url_length=${#line}
+  # Local path where the file will be downloaded
+  full_path=${line##*$folder}
+  # Download files and keep the folders structure
+  echo -e "Downloading data from $line \n"
+  mkdir -p $(dirname $full_path)
+  curl $line --output $full_path
+  echo "File saved in $full_path"
+  echo -e "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - \n"
+done < "$input"

--- a/requester_docs.md
+++ b/requester_docs.md
@@ -1,0 +1,55 @@
+---
+layout: article
+title: Requester Docs
+key: page-single
+---
+
+## Download Instructions
+
+This sections provides guidelines and intructions on how to download the data files. It contains three steps - Generate Public and Secret Key, Decrypt the data files and Validate the decrypt data files. 
+
+### Preparing the system
+
+Downloading data files requires [crypt4gh](https://www.ga4gh.org/news/crypt4gh-a-secure-method-for-sharing-human-genetic-data/)
+for decrypting the data files. 
+
+
+### Generate Public and Secret Key
+
+The first step is to generate a keypair using the `crypt4gh` encryption tool. This can be done using the following command. There are two keys generated - `user.sec` is the secret key and `user.pub` is the public key. You must reply to the FEGA-SE helpdesk by sending them the generated public key - `user.pub`. 
+
+```bash
+crypt4gh-keygen --sk user.sec --pk user.pub
+```
+
+### Decrypt the data files
+
+You recieve an email from the FEGA-SE helpdesk that contains a URL. This URL contains links to download the encrypted data files. Download the `download_data` script from [here](download_data.html) and use the following command.
+
+
+```bash
+./download_data.sh
+```
+In case the name of the text file is changed or it exists in a different path than the download script, run:
+
+```bash
+./download_data.sh path/filename
+```
+
+This downloads all the encrypted files from the text file and allows it to maintain the structure of the dataset. Next, you must transfer the downloaded encrypt files and the secret key to a secure environment. Use the following command to decrypt files inside the secure environment using the secret key - `user.sec` that was generated in the previous step.
+
+```bash
+crypt4gh decrypt --sk user.sec < encrypted-file.c4gh > encrypted-file
+```
+Ensure that the `encrypted-file.c4gh` and the corresponding `encrypted-file` are in the same folder. 
+
+
+### Validate the decrypt files
+
+The next step is to validate the decrypted files. This can be done using calculating checksums of the downloaded files. Executing the `download_data` script downloads a file `checksums_list.sha256` that contains the list of checksums. Following command is used to validate the decrypted file.
+
+```bash
+sha256sum -c checksums_list.sha256
+```
+
+In the end, you must reply to FEGA-SE helpback to confirm successful download and decryption.

--- a/submitter_docs.md
+++ b/submitter_docs.md
@@ -1,0 +1,138 @@
+---
+layout: article
+title: Submitter Docs
+key: page-single
+---
+
+# EGA-SE-user-docs
+
+This repository contains user information on how to submit files to the swedish
+Sensitive Data Archive (SDA) service. This document serves as an outline of the submission process, 
+and links to more detailed guides on how to perform the individual steps for creating a submission.
+
+## Preparing the data
+
+There are currently no restrictions on what kinds of files are allowed to upload
+to the SDA. Our recommendation is to still spend some time to see if there are
+file types intended for archiving available for your data, and use those. For
+example - for alignment data, use the cram format instead of sam/bam.
+
+## Preparing the system
+
+Submitting data requires two tools,
+[crypt4gh](https://www.ga4gh.org/news/crypt4gh-a-secure-method-for-sharing-human-genetic-data/)
+for encrypting the data, and [s3cmd](https://s3tools.org/s3cmd) for uploading to
+the SDA.
+
+To prepare the system follow the instructions [here](binaries.html). This is a **required step**
+whether you work on bianca or any other system.
+
+**Note** If you are using Bianca, see the [Encrypting on Bianca](bianca.html)
+instructions which cover transferring the crypt4gh tool and the public key to 
+bianca.
+
+## Encrypting
+
+The first step of a submission is to encrypt the submission data files with the
+`crypt4gh` encryption tool. This is fairly straight forward in the general case,
+but needs a few extra steps on Bianca as the system isn't directly
+connected to the internet. This process is detailed in the
+[Encrypting on Bianca](bianca.html) document, which covers the following steps:
+
+  - [Login to uppmax](bianca.html#login-to-uppmax)
+
+  - [Install crypt4gh on Bianca](bianca.html#install-crypt4gh-on-bianca)
+
+  - [Encrypt your sensitive data](bianca.html#encrypt-your-sensitive-data)
+
+  - [Move the encrypted files to the wharf](bianca.html#move-encrypted-files-to-the-wharf-for-upload)
+
+Outside of Bianca, this can be limited to these two or three steps:
+
+ - Download the crypt4gh public key
+
+   For the SDA to be able to understand the encrypted files when they are
+   uploaded, they need to be encrypted with the correct public key. This key can
+   be downloaded from this repository with this command:
+   ```bash
+   wget https://raw.githubusercontent.com/NBISweden/EGA-SE-user-docs/main/crypt4gh_key.pub
+   ```
+
+ - (Optional) Create a personal key pair​
+
+   The creation of a key pair is very simple using crypt4gh. Run the following
+   command, replacing [my-key] with the name of the key (can be anything) and
+   specifying a passphrase when requested:
+​
+   ```bash
+   crypt4gh generate --name=[my-key]
+   ```
+
+   To verify that the key pair was created, run the `ls` command and make sure
+   the keys you specified exist in the folder.
+
+ - Encrypt the files
+
+   Now that you have the public key, and the tools you need, you can encrypt the
+   submission files. An encryption key will be created automatically by the
+   tool, but if you prefer to use a specific key, you can provide one using the
+   `-s` argument.
+
+   ```bash
+   ./crypt4gh encrypt -p crypt4gh_key.pub -f [my-file] [-s [my-key].sec.pem]
+   ```
+
+## Submitting
+
+Once your files are encrypted, you are almost ready to start submitting to the
+SDA. There is just one more thing that is needed; checksums for the files.
+
+### Get checksums of the files
+​
+Once the files are uploaded, they need to be validated, which will require you to enter md5 and sha256 checksums for each file. 
+To prepare for this later step, it's advised to create checksums for all files as you upload them.
+
+Check our short guide on [Calculating checksums of files](checksums.html) for details.
+​
+### Get the configuration file
+​
+The s3cmd tool requires a configuration file with the relevant settings. You
+can get the configuration file by logging in with your Elixir ID
+[here](https://login.sda.nbis.se/).
+
+If you choose not to use the downloaded configuration file, we recommend
+setting the multipart chunk size significantly higher than the default 5 Mbyte.
+It can be set up to 2 Gbytes but values above 100 Mbyte probably do very little
+to improve throughput.
+
+**NOTE**: The following section requires the usage of `[username]` when uploading data.
+The username refers to the value of the `secret_key` in the downloaded configuration file. 
+Make sure to get it from the configuration file and use it in all `s3cmd` commands.
+
+### Upload the file(s)​
+
+S3 allows for **optional** creation of folders. Folder creation is automatic
+when adding a directory name to a file upload.
+​
+For example, if `file1.c4gh` should be stored under the `experiment1` folder,
+the command would look like:
+​
+```bash
+./s3cmd-2.2.0/s3cmd -v -c /path/s3-config put [my-path-to-file1.c4gh] "s3://[username]/experiment1/file1.c4gh"
+```
+​
+while in case no folder needs to be created, the command would look like:
+​
+```bash
+./s3cmd-2.2.0/s3cmd -v -c /path/s3-config put [my-path-to-file1.c4gh] "s3://[username]/file1.c4gh"
+```
+​
+Once the upload is finished, make sure the file was uploaded, by running the
+following command:
+​
+```bash
+./s3cmd-2.2.0/s3cmd -v -c [my-path-to-s3-config] ls "s3://[username]/[my-s3-path]/"
+```
+​
+You should be able to see the file and potentially others stored in the same
+location.


### PR DESCRIPTION
Added the SDA User-docs to the web portal. I have added it as submitter information, requesting information and `download_data.sh` to the footer of the page. 